### PR TITLE
Add handlers for location as NavSatFixes to/from ROS

### DIFF
--- a/scripts/telegram_ros_bridge
+++ b/scripts/telegram_ros_bridge
@@ -19,7 +19,7 @@ class TelegramROSBridge(object):
     def __init__(self, api_token, caption_as_frame_id):
         # ROS IO
         """
-        Telegram ROS bridge that bridges between a telegram chat conversation and ROS        
+        Telegram ROS bridge that bridges between a telegram chat conversation and ROS
         :param api_token: The telegram API token
         """
         self._caption_as_frame_id = caption_as_frame_id
@@ -33,7 +33,7 @@ class TelegramROSBridge(object):
         self._to_telegram_image_subscriber = rospy.Subscriber("image_from_ros", Image,
                                                               self._ros_image_callback, queue_size=10)
         self._to_telegram_location_subscriber = rospy.Subscriber("location_from_ros", NavSatFix,
-                                                              self._ros_location_callback, queue_size=10)
+                                                                 self._ros_location_callback, queue_size=10)
         # Set CvBridge
         self._cv_bridge = CvBridge()
 
@@ -46,7 +46,8 @@ class TelegramROSBridge(object):
         self._telegram_updater.dispatcher.add_handler(CommandHandler("start", self._telegram_start_callback))
         self._telegram_updater.dispatcher.add_handler(MessageHandler(Filters.text, self._telegram_message_callback))
         self._telegram_updater.dispatcher.add_handler(MessageHandler(Filters.photo, self._telegram_photo_callback))
-        self._telegram_updater.dispatcher.add_handler(MessageHandler(Filters.location, self._telegram_location_callback))
+        self._telegram_updater.dispatcher.add_handler(
+            MessageHandler(Filters.location, self._telegram_location_callback))
 
     def spin(self):
         """
@@ -64,7 +65,7 @@ class TelegramROSBridge(object):
         """
         Called when a telegram user sends the '/start' event to the bot, using this event, the bridge can be connected
         to a specific conversation
-        :param update: Received update event that holds the chat_id and message data 
+        :param update: Received update event that holds the chat_id and message data
         """
         if self._telegram_chat_id is not None and self._telegram_chat_id != update.message.chat_id:
             rospy.logwarn("Changing to different chat_id!")
@@ -157,7 +158,7 @@ class TelegramROSBridge(object):
         """
         location = update.message.location
         rospy.loginfo("Incoming location from telegram: {}".format(location))
-        
+
         if self._telegram_chat_id is None:
             rospy.logwarn("Discarding message. No active chat_id.")
             update.message.reply_text("ROS Bridge not initialized. Type /start to set-up ROS bridge")
@@ -167,7 +168,7 @@ class TelegramROSBridge(object):
                 "ROS Bridge initialized to another chat_id. Type /start to connect to this chat_id")
         else:
             navsatfix = NavSatFix()
-            sec_since_epoch = (update.message.date - datetime.datetime(1970,1,1)).total_seconds()
+            sec_since_epoch = (update.message.date - datetime.datetime(1970, 1, 1)).total_seconds()
             navsatfix.header.stamp = rospy.Time.from_sec(sec_since_epoch)
             navsatfix.latitude = location.latitude
             navsatfix.longitude = location.longitude
@@ -187,6 +188,7 @@ class TelegramROSBridge(object):
                 self._telegram_updater.bot.send_location(self._telegram_chat_id, location=location)
             except TimedOut as e:
                 rospy.logerr("Failed to send location {}: {}".format(location, e))
+
 
 if __name__ == '__main__':
     rospy.init_node('telegram_ros_bridge')

--- a/scripts/telegram_ros_bridge
+++ b/scripts/telegram_ros_bridge
@@ -152,29 +152,28 @@ class TelegramROSBridge(object):
     def _telegram_location_callback(self, _, update):
         """
         Called when a new telegram Location is received. The method will verify whether the incoming Location is
-        from the bridges telegram conversation by comparing the chat_id.
+        from the bridged telegram conversation by comparing the chat_id.
         :param update: Received update that holds the chat_id and message data
         """
         location = update.message.location
-        if isinstance(location, Location):
-            rospy.loginfo("Incoming location from telegram: {}".format(location))
-            if self._telegram_chat_id is None:
-                rospy.logwarn("Discarding message. No active chat_id.")
-                update.message.reply_text("ROS Bridge not initialized. Type /start to set-up ROS bridge")
-            elif self._telegram_chat_id != update.message.chat_id:
-                rospy.logwarn("Discarding message. Invalid chat_id")
-                update.message.reply_text(
-                    "ROS Bridge initialized to another chat_id. Type /start to connect to this chat_id")
-            else:
-                navsatfix = NavSatFix()
-                navsatfix.header.stamp = update.message.date # TODO convert tot ROS Time
-                sec_since_epoch = (update.message.date - datetime.datetime(1970,1,1)).total_seconds()
-                navsatfix.header.stamp = rospy.Time.from_sec(sec_since_epoch)
-                navsatfix.header.frame_id = "telegram"
-                navsatfix.latitude = location.latitude
-                navsatfix.longitude = location.longitude
-                navsatfix.position_covariance_type = NavSatFix.COVARIANCE_TYPE_UNKNOWN
-                self._from_telegram_location_publisher.publish(navsatfix)
+        rospy.loginfo("Incoming location from telegram: {}".format(location))
+        
+        if self._telegram_chat_id is None:
+            rospy.logwarn("Discarding message. No active chat_id.")
+            update.message.reply_text("ROS Bridge not initialized. Type /start to set-up ROS bridge")
+        elif self._telegram_chat_id != update.message.chat_id:
+            rospy.logwarn("Discarding message. Invalid chat_id")
+            update.message.reply_text(
+                "ROS Bridge initialized to another chat_id. Type /start to connect to this chat_id")
+        else:
+            navsatfix = NavSatFix()
+            navsatfix.header.stamp = update.message.date # TODO convert tot ROS Time
+            sec_since_epoch = (update.message.date - datetime.datetime(1970,1,1)).total_seconds()
+            navsatfix.header.stamp = rospy.Time.from_sec(sec_since_epoch)
+            navsatfix.latitude = location.latitude
+            navsatfix.longitude = location.longitude
+            navsatfix.position_covariance_type = NavSatFix.COVARIANCE_TYPE_UNKNOWN
+            self._from_telegram_location_publisher.publish(navsatfix)
 
     def _ros_location_callback(self, msg):
         """

--- a/scripts/telegram_ros_bridge
+++ b/scripts/telegram_ros_bridge
@@ -4,13 +4,15 @@
 from StringIO import StringIO
 
 import cv2
+import datetime
 import numpy as np
 import rospy
 from cv_bridge import CvBridge
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, NavSatFix
 from std_msgs.msg import String
 from telegram.error import TimedOut
 from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
+from telegram import Location
 
 
 class TelegramROSBridge(object):
@@ -24,10 +26,14 @@ class TelegramROSBridge(object):
 
         self._from_telegram_string_publisher = rospy.Publisher("message_to_ros", String, queue_size=10)
         self._from_telegram_image_publisher = rospy.Publisher("image_to_ros", Image, queue_size=10)
+        self._from_telegram_location_publisher = rospy.Publisher("location_to_ros", NavSatFix, queue_size=10)
+
         self._to_telegram_string_subscriber = rospy.Subscriber("message_from_ros", String,
                                                                self._ros_string_callback, queue_size=10)
         self._to_telegram_image_subscriber = rospy.Subscriber("image_from_ros", Image,
                                                               self._ros_image_callback, queue_size=10)
+        self._to_telegram_location_subscriber = rospy.Subscriber("location_from_ros", NavSatFix,
+                                                              self._ros_location_callback, queue_size=10)
         # Set CvBridge
         self._cv_bridge = CvBridge()
 
@@ -36,9 +42,11 @@ class TelegramROSBridge(object):
         self._telegram_updater = Updater(api_token)
         self._telegram_updater.dispatcher.add_error_handler(
             lambda _, update, error: rospy.logerr("Update {} caused error {}".format(update, error)))
+
         self._telegram_updater.dispatcher.add_handler(CommandHandler("start", self._telegram_start_callback))
         self._telegram_updater.dispatcher.add_handler(MessageHandler(Filters.text, self._telegram_message_callback))
         self._telegram_updater.dispatcher.add_handler(MessageHandler(Filters.photo, self._telegram_photo_callback))
+        self._telegram_updater.dispatcher.add_handler(MessageHandler(Filters.location, self._telegram_location_callback))
 
     def spin(self):
         """
@@ -141,6 +149,46 @@ class TelegramROSBridge(object):
             self._telegram_updater.bot.send_photo(self._telegram_chat_id,
                                                   photo=StringIO(cv2.imencode('.jpg', cv2_img)[1].tostring()))
 
+    def _telegram_location_callback(self, _, update):
+        """
+        Called when a new telegram Location is received. The method will verify whether the incoming Location is
+        from the bridges telegram conversation by comparing the chat_id.
+        :param update: Received update that holds the chat_id and message data
+        """
+        location = update.message.location
+        if isinstance(location, Location):
+            rospy.loginfo("Incoming location from telegram: {}".format(location))
+            if self._telegram_chat_id is None:
+                rospy.logwarn("Discarding message. No active chat_id.")
+                update.message.reply_text("ROS Bridge not initialized. Type /start to set-up ROS bridge")
+            elif self._telegram_chat_id != update.message.chat_id:
+                rospy.logwarn("Discarding message. Invalid chat_id")
+                update.message.reply_text(
+                    "ROS Bridge initialized to another chat_id. Type /start to connect to this chat_id")
+            else:
+                navsatfix = NavSatFix()
+                navsatfix.header.stamp = update.message.date # TODO convert tot ROS Time
+                sec_since_epoch = (update.message.date - datetime.datetime(1970,1,1)).total_seconds()
+                navsatfix.header.stamp = rospy.Time.from_sec(sec_since_epoch)
+                navsatfix.header.frame_id = "telegram"
+                navsatfix.latitude = location.latitude
+                navsatfix.longitude = location.longitude
+                navsatfix.position_covariance_type = NavSatFix.COVARIANCE_TYPE_UNKNOWN
+                self._from_telegram_location_publisher.publish(navsatfix)
+
+    def _ros_location_callback(self, msg):
+        """
+        Called when a new ROS NavSatFix message is coming in that should be send to the telegram conversation
+        :param msg: NavSatFix that the robot wants to share
+        """
+        if not self._telegram_chat_id:
+            rospy.logerr("ROS Bridge not initialized, dropping string message")
+        else:
+            location = Location(msg.longitude, msg.latitude)
+            try:
+                self._telegram_updater.bot.send_location(self._telegram_chat_id, location=location)
+            except TimedOut as e:
+                rospy.logerr("Failed to send location {}: {}".format(location, e))
 
 if __name__ == '__main__':
     rospy.init_node('telegram_ros_bridge')

--- a/scripts/telegram_ros_bridge
+++ b/scripts/telegram_ros_bridge
@@ -182,7 +182,7 @@ class TelegramROSBridge(object):
         :param msg: NavSatFix that the robot wants to share
         """
         if not self._telegram_chat_id:
-            rospy.logerr("ROS Bridge not initialized, dropping string message")
+            rospy.logerr("ROS Bridge not initialized, dropping location message")
         else:
             location = Location(msg.longitude, msg.latitude)
             try:

--- a/scripts/telegram_ros_bridge
+++ b/scripts/telegram_ros_bridge
@@ -167,7 +167,6 @@ class TelegramROSBridge(object):
                 "ROS Bridge initialized to another chat_id. Type /start to connect to this chat_id")
         else:
             navsatfix = NavSatFix()
-            navsatfix.header.stamp = update.message.date # TODO convert tot ROS Time
             sec_since_epoch = (update.message.date - datetime.datetime(1970,1,1)).total_seconds()
             navsatfix.header.stamp = rospy.Time.from_sec(sec_since_epoch)
             navsatfix.latitude = location.latitude


### PR DESCRIPTION
Send and receive locations in Telegram as NavSatFix in ROS. 
NavSatFix seemed the most relevant and best message type for this, because it is after all a NavSatFix if you share your location through Telegram base don your phone's GPS. 

Another benefit of NavSatFix is that this does not add more dependencies