### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
-sudo: true
+sudo: required
+language: generic
+dist: trusty
 
-language: cpp
+matrix:
+  include:
+  - name: "Kinetic"
+    env: ROS_DISTRO=kinetic
 
-services:
-  - docker
-
-before_install:
-  - wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/install-package.sh
-  - wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/build-package.sh
-  - export PACKAGE=${TRAVIS_REPO_SLUG#*/}
+  - name: "Melodic"
+    env: ROS_DISTRO=melodic
 
 install:
-  - bash install-package.sh --package=$PACKAGE --branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} --commit=$TRAVIS_COMMIT --pullrequest=$TRAVIS_PULL_REQUEST
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 
 script:
-  - bash build-package.sh --package=$PACKAGE
+  - .ci_config/travis.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Bridges between a [Telegram](https://telegram.org/) conversation and [ROS](http://ros.org).
 
+## Travis CI Build Status
+
+[![Build Status](https://travis-ci.org/tue-robotics/telegram_ros.svg)](https://travis-ci.org/tue-robotics/telegram_ros)
+
 ## Installation (from source)
 
 Go to the `src` directory of your catkin workspace and clone the package from github:


### PR DESCRIPTION
Use industrial CI instead of custom TUE. This makes sure that other uses can also install the packages using the default ROS tooling (and the installation manual is valid).