### PR TITLE
Bump min cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(telegram_ros)
 find_package(catkin REQUIRED)
 


### PR DESCRIPTION
Lower minimum cmake requirement is not supported anymore